### PR TITLE
🐛 Fix error when `u2f` or `origin` are not available

### DIFF
--- a/src/device/index.js
+++ b/src/device/index.js
@@ -154,6 +154,15 @@ class LedgerDevice {
    * @param {U2F} attributes.u2f - The implementation of the U2F API to use
    */
   constructor({ accountIndex, appId, path, timeout, u2f }) {
+    const missingParameters = [
+      !appId && 'appId',
+      !u2f && 'u2f'
+    ].filter(Boolean);
+
+    if (missingParameters.length > 0) {
+      throw new Error(`ArgumentError: Missing required parameter(s): ${missingParameters.join(', ')}`);
+    }
+
     this.attributes = {
       accountIndex: accountIndex || 0,
       appId,

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -6,6 +6,7 @@ import createGetAddressRequest from './get-address/request';
 import createSignRequest from './sign/request';
 import parseGetAddressResponse from './get-address/response';
 import parseSignResponse from './sign/response';
+import requireParameters from '../helpers/require-parameters';
 
 const U2FSignError = [
   () => new Error('OK: The operation completed successfully.'),
@@ -154,14 +155,7 @@ class LedgerDevice {
    * @param {U2F} attributes.u2f - The implementation of the U2F API to use
    */
   constructor({ accountIndex, appId, path, timeout, u2f }) {
-    const missingParameters = [
-      !appId && 'appId',
-      !u2f && 'u2f'
-    ].filter(Boolean);
-
-    if (missingParameters.length > 0) {
-      throw new Error(`ArgumentError: Missing required parameter(s): ${missingParameters.join(', ')}`);
-    }
+    requireParameters('appId', 'u2f')({ appId, u2f });
 
     this.attributes = {
       accountIndex: accountIndex || 0,

--- a/src/device/spec.js
+++ b/src/device/spec.js
@@ -1,10 +1,26 @@
 /* eslint no-magic-numbers: ['off'] */
 /* eslint sort-keys: ['off'] */
 
-import { expect, story, stub } from '../spec.helpers';
+import { context, describe, expect, it, story, stub } from '../spec.helpers';
 
 import { Buffer } from 'buffer';
 import LedgerDevice from '.';
+
+describe('LedgerDevice', () => {
+  describe('#constructor()', () => {
+    context('when appId is missing', () => {
+      it('should throw an error', () => {
+        expect(() => new LedgerDevice({ u2f: {} })).to.throw(Error, /ArgumentError/g);
+      });
+    });
+
+    context('when u2f is missing', () => {
+      it('should throw an error', () => {
+        expect(() => new LedgerDevice({ appId: 'APP_ID' })).to.throw(Error, /ArgumentError/g);
+      });
+    });
+  });
+});
 
 story('LedgerDevice#sign()', {
   given: () => [

--- a/src/helpers/require-parameters/index.js
+++ b/src/helpers/require-parameters/index.js
@@ -1,0 +1,25 @@
+/**
+ * This function provides a convenient way to assert the presence of required
+ * named parameters.
+ *
+ * @param {...string} parameterNames - The keys to assert are defined in the
+ * named parameters.
+ *
+ * @return {Function} - Returns a function that accepts an object containing
+ * named parameters, which throws an Error if any of the parameters marked as
+ * required are undefined.
+ */
+const requireParameters = (...parameterNames) => (givenParameters = {}) => {
+  const missingParameters = parameterNames.reduce((missingParameters, name) => {
+    if (typeof givenParameters[name] === 'undefined') {
+      missingParameters.push(name);
+    }
+    return missingParameters;
+  }, []);
+
+  if (missingParameters.length > 0) {
+    throw new Error(`ArgumentError: Missing required parameter(s): ${missingParameters.join(', ')}`);
+  }
+};
+
+export default requireParameters;

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,16 @@ class LedgerProvider {
    * @param {LedgerDevice} [attributes.device] - The Ledger device to use. Defaults to a Ledger Nano S device using the default account, using a U2F API provided by a `u2f` global, and using an appId of the `origin` global.
    */
   constructor(attributes = {}) {
+    if (!attributes.device) {
+      if (!attributes.u2f && typeof(u2f) === 'undefined') {
+        throw new Error('ArgumentError: No device or `u2f` implementation given, and the U2F API is not provided in this context. Please provide a device or a `u2f` implementation.');
+      }
+
+      if (!attributes.appId && typeof(origin) === 'undefined') {
+        throw new Error('ArgumentError: No device or `appId` given, and the application ID cannot be derived from the origin in this context. Please provide a device or an `appId`.')
+      }
+    }
+
     const device = attributes.device || new LedgerDevice({
       accountIndex: attributes.accountIndex,
       appId: attributes.appId || origin,

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
 import LedgerDevice from './device';
 import RPC from './rpc';
 
+import requireParameters from './helpers/require-parameters';
+
 const JSONRPC_VERSION = '2.0';
 
 /**
@@ -21,13 +23,7 @@ class LedgerProvider {
    */
   constructor(attributes = {}) {
     if (!attributes.device) {
-      if (!attributes.u2f && typeof(u2f) === 'undefined') {
-        throw new Error('ArgumentError: No device or `u2f` implementation given, and the U2F API is not provided in this context. Please provide a device or a `u2f` implementation.');
-      }
-
-      if (!attributes.appId && typeof(origin) === 'undefined') {
-        throw new Error('ArgumentError: No device or `appId` given, and the application ID cannot be derived from the origin in this context. Please provide a device or an `appId`.')
-      }
+      requireParameters('appId', 'u2f')(attributes);
     }
 
     const device = attributes.device || new LedgerDevice({

--- a/src/spec.js
+++ b/src/spec.js
@@ -25,6 +25,22 @@ const u2f = {
 };
 
 describe('LedgerProvider', () => {
+  describe('#constructor()', () => {
+    context('without a device', () => {
+      context('with no U2F implementation', () => {
+        it('should throw an error', () => {
+          expect(() => new LedgerProvider({ appId: origin })).to.throw(Error, /ArgumentError/g);
+        });
+      });
+
+      context('with no appId', () => {
+        it('should throw an error', () => {
+          expect(() => new LedgerProvider({ u2f })).to.throw(Error, /ArgumentError/g);
+        });
+      });
+    });
+  });
+
   const ledgerProvider = new LedgerProvider({
     device: new LedgerDevice({ appId: origin, u2f })
   });


### PR DESCRIPTION
Fixes [#5](https://github.com/blockmason/web3-provider-ledger/issues/5).

This error occurs in Webpack builds because `u2f` is not considered by Webpack, by default, to be an available global variable.

 * Better enforcement of required parameters in constructors for `LedgerDevice` and `LedgerProvider`.